### PR TITLE
Change navigation when using DoAsync<TCurrentNode, TNodeOut>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ msbuild.wrn
 # Tests
 TestResults/
 StrykerOutput/
+*.received.*

--- a/src/Caravel.Abstractions/IJourney.cs
+++ b/src/Caravel.Abstractions/IJourney.cs
@@ -16,4 +16,11 @@ public interface IJourney
         CancellationToken localCancellationToken
     )
         where TDestination : INode;
+
+    public Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+        where TNodeOut : INode;
 }

--- a/src/Caravel.Abstractions/IJourney.cs
+++ b/src/Caravel.Abstractions/IJourney.cs
@@ -23,4 +23,11 @@ public interface IJourney
     )
         where TCurrentNode : INode
         where TNodeOut : INode;
+
+    public Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+        where TNodeOut : INode;
 }

--- a/src/Caravel.Abstractions/IJourney.cs
+++ b/src/Caravel.Abstractions/IJourney.cs
@@ -18,13 +18,6 @@ public interface IJourney
         where TDestination : INode;
 
     public Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
-        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
-        CancellationToken localCancellationToken = default
-    )
-        where TCurrentNode : INode
-        where TNodeOut : INode;
-
-    public Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
         Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
         CancellationToken localCancellationToken = default
     )

--- a/src/Caravel.Core/Extensions/JourneyExtensions.Task.cs
+++ b/src/Caravel.Core/Extensions/JourneyExtensions.Task.cs
@@ -101,6 +101,33 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
     }
 
+    public static async Task<IJourney> DoAsync<TCurrentNode>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TCurrentNode>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+
+        var journey = await journeyTask.ConfigureAwait(false);
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+        where TNodeOut : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+
+        var journey = await journeyTask.ConfigureAwait(false);
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+    }
+
     internal static CancellationTokenSource LinkJourneyAndLocalCancellationTokens(
         this IJourney journey,
         CancellationToken localCancellationToken

--- a/src/Caravel.Core/Extensions/JourneyExtensions.Task.cs
+++ b/src/Caravel.Core/Extensions/JourneyExtensions.Task.cs
@@ -84,7 +84,9 @@ public static partial class JourneyExtensions
         ArgumentNullException.ThrowIfNull(func, nameof(func));
 
         var journey = await journeyTask.ConfigureAwait(false);
-        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+        return await journey
+            .DoAsync<TCurrentNode, TCurrentNode>(func, localCancellationToken)
+            .ConfigureAwait(false);
     }
 
     public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(

--- a/src/Caravel.Core/Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core/Extensions/JourneyExtensions.cs
@@ -69,8 +69,18 @@ public static partial class JourneyExtensions
         where TCurrentNode : INode
     {
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
-        return await Task.FromResult(journey)
-            .DoAsync<TCurrentNode>(func, localCancellationToken)
-            .ConfigureAwait(false);
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+        this IJourney journey,
+        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+        where TNodeOut : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Caravel.Core/Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core/Extensions/JourneyExtensions.cs
@@ -83,4 +83,27 @@ public static partial class JourneyExtensions
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
         return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
     }
+
+    public static async Task<IJourney> DoAsync<TCurrentNode>(
+        this IJourney journey,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TCurrentNode>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+        this IJourney journey,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        CancellationToken localCancellationToken = default
+    )
+        where TCurrentNode : INode
+        where TNodeOut : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/Caravel.Core/Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core/Extensions/JourneyExtensions.cs
@@ -69,7 +69,12 @@ public static partial class JourneyExtensions
         where TCurrentNode : INode
     {
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
-        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+        return await journey
+            .DoAsync<TCurrentNode, TCurrentNode>(
+                (_, node, token) => func(node, token),
+                localCancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
@@ -81,7 +86,12 @@ public static partial class JourneyExtensions
         where TNodeOut : INode
     {
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
-        return await journey.DoAsync(func, localCancellationToken).ConfigureAwait(false);
+        return await journey
+            .DoAsync<TCurrentNode, TNodeOut>(
+                (_, node, token) => func(node, token),
+                localCancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     public static async Task<IJourney> DoAsync<TCurrentNode>(

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -91,39 +91,7 @@ public abstract class Journey : IJourney, IJourneyLegPublisher
         where TCurrentNode : INode
         where TNodeOut : INode
     {
-        ArgumentNullException.ThrowIfNull(func);
-
-        return await InternalDoAsync<TCurrentNode, TNodeOut>(
-                (journey, node, token) => func(journey, node, token),
-                localCancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
-    public async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
-        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
-        CancellationToken localCancellationToken = default
-    )
-        where TCurrentNode : INode
-        where TNodeOut : INode
-    {
-        ArgumentNullException.ThrowIfNull(func);
-
-        return await InternalDoAsync<TCurrentNode, TNodeOut>(
-                (_, node, token) => func(node, token),
-                localCancellationToken
-            )
-            .ConfigureAwait(false);
-    }
-
-    private async Task<IJourney> InternalDoAsync<TCurrentNode, TNodeOut>(
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> wrappedFunc,
-        CancellationToken localCancellationToken = default
-    )
-        where TCurrentNode : INode
-        where TNodeOut : INode
-    {
-        ArgumentNullException.ThrowIfNull(wrappedFunc, nameof(wrappedFunc));
+        ArgumentNullException.ThrowIfNull(func, nameof(func));
 
         using var linkedCancellationTokenSource = this.LinkJourneyAndLocalCancellationTokens(
             localCancellationToken
@@ -138,7 +106,7 @@ public abstract class Journey : IJourney, IJourneyLegPublisher
         // Validate the CurrentNode at each steps.
         if (CurrentNode is TCurrentNode current)
         {
-            var funcNode = await wrappedFunc(this, current, linkedCancellationTokenSource.Token)
+            var funcNode = await func(this, current, linkedCancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             // Ensure the navigation from DoAsync is registered.

--- a/test/Caravel.Tests.Fixtures/GlobalSuppressions.cs
+++ b/test/Caravel.Tests.Fixtures/GlobalSuppressions.cs
@@ -6,13 +6,6 @@
 using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage(
-    "Naming",
-    "CA1707:Identifiers should not contain underscores",
-    Justification = "Readability",
-    Scope = "namespaceanddescendants",
-    Target = "~N:Caravel.Tests.Fixtures.GraphsData"
-)]
-[assembly: SuppressMessage(
     "Style",
     "IDE0290:Use primary constructor",
     Justification = "Suggestion not wanted."

--- a/test/Caravel.Tests.Fixtures/INodeSpy.cs
+++ b/test/Caravel.Tests.Fixtures/INodeSpy.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Caravel.Abstractions;
 
-namespace Caravel.Tests.Fixtures.NodeSpies;
+namespace Caravel.Tests.Fixtures;
 
 public interface INodeSpy : INode
 {

--- a/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
+++ b/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
@@ -2,7 +2,6 @@
 using Caravel.Abstractions;
 using Caravel.Core;
 using Caravel.Graph.Dijkstra;
-using Caravel.Tests.Fixtures.NodeSpies;
 
 namespace Caravel.Tests.Fixtures;
 

--- a/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
+++ b/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
@@ -9,6 +9,7 @@ public sealed class JourneyBuilder
 {
     private readonly Dictionary<Type, NodeBuilder> _nodes = [];
     private Type? _firstNodeType;
+    private Map? _map;
 
     public NodeBuilder AddNode<T>()
         where T : INodeSpy
@@ -26,7 +27,8 @@ public sealed class JourneyBuilder
 
     public ImmutableDictionary<Type, NodeBuilder> Nodes => _nodes.ToImmutableDictionary();
     public Type Node => _firstNodeType!;
-    public Map? Map { get; private set; }
+
+    public Map Map => _map!;
 
     public IJourney Build(TimeProvider? timeProvider = default, CancellationToken ct = default)
     {
@@ -43,7 +45,7 @@ public sealed class JourneyBuilder
         }
 
         // Set Map
-        Map = new Map([.. nodeInstances.Values]);
+        _map = new Map([.. nodeInstances.Values]);
 
         // Link edge MoveNext handlers to return neighbor from map
         foreach (var builder in _nodes.Values)

--- a/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
+++ b/test/Caravel.Tests.Fixtures/JourneyBuilder.cs
@@ -26,6 +26,7 @@ public sealed class JourneyBuilder
 
     public ImmutableDictionary<Type, NodeBuilder> Nodes => _nodes.ToImmutableDictionary();
     public Type Node => _firstNodeType!;
+    public Map? Map { get; private set; }
 
     public IJourney Build(TimeProvider? timeProvider = default, CancellationToken ct = default)
     {
@@ -40,6 +41,9 @@ public sealed class JourneyBuilder
             var node = builder.CreateNode(edges);
             nodeInstances[type] = node;
         }
+
+        // Set Map
+        Map = new Map([.. nodeInstances.Values]);
 
         // Link edge MoveNext handlers to return neighbor from map
         foreach (var builder in _nodes.Values)

--- a/test/Caravel.Tests.Fixtures/Map.cs
+++ b/test/Caravel.Tests.Fixtures/Map.cs
@@ -1,0 +1,26 @@
+﻿using Caravel.Abstractions;
+
+namespace Caravel.Tests.Fixtures;
+
+public sealed class Map
+{
+    private readonly ICollection<INode> _nodes;
+
+    public Map(ICollection<INode> nodes)
+    {
+        _nodes = nodes;
+    }
+
+    public NodeSpy1 NodeSpy1 => GetNode<NodeSpy1>();
+    public NodeSpy2 NodeSpy2 => GetNode<NodeSpy2>();
+    public NodeSpy3 NodeSpy3 => GetNode<NodeSpy3>();
+    public NodeSpy4 NodeSpy4 => GetNode<NodeSpy4>();
+    public NodeSpy5 NodeSpy5 => GetNode<NodeSpy5>();
+    public NodeSpy6 NodeSpy6 => GetNode<NodeSpy6>();
+    public NodeSpy7 NodeSpy7 => GetNode<NodeSpy7>();
+    public NodeSpy8 NodeSpy8 => GetNode<NodeSpy8>();
+    public NodeSpy9 NodeSpy9 => GetNode<NodeSpy9>();
+
+    private T GetNode<T>()
+        where T : INode => (T)_nodes.Where(x => x.GetType() == typeof(T)).Single();
+}

--- a/test/Caravel.Tests.Fixtures/NodeSpies.cs
+++ b/test/Caravel.Tests.Fixtures/NodeSpies.cs
@@ -56,9 +56,3 @@ public sealed class NodeSpy9 : NodeSpyBase
     public NodeSpy9(ImmutableHashSet<IEdge> edges, bool existValue = true)
         : base(edges, existValue) { }
 }
-
-public sealed class NodeSpy10 : NodeSpyBase
-{
-    public NodeSpy10(ImmutableHashSet<IEdge> edges, bool existValue = true)
-        : base(edges, existValue) { }
-}

--- a/test/Caravel.Tests.Fixtures/NodeSpies.cs
+++ b/test/Caravel.Tests.Fixtures/NodeSpies.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Caravel.Abstractions;
 
-namespace Caravel.Tests.Fixtures.NodeSpies;
+namespace Caravel.Tests.Fixtures;
 
 public sealed class NodeSpy1 : NodeSpyBase
 {

--- a/test/Caravel.Tests.Fixtures/NodeSpyBase.cs
+++ b/test/Caravel.Tests.Fixtures/NodeSpyBase.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Caravel.Abstractions;
 
-namespace Caravel.Tests.Fixtures.NodeSpies;
+namespace Caravel.Tests.Fixtures;
 
 public class NodeSpyBase : INodeSpy
 {

--- a/test/UnitTests/Caravel.Core.UnitTests/GlobalUsing.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/GlobalUsing.cs
@@ -1,7 +1,6 @@
 ﻿global using Caravel.Core.Extensions;
 global using Caravel.Core.UnitTests.Extensions;
 global using Caravel.Tests.Fixtures;
-global using Caravel.Tests.Fixtures.NodeSpies;
 global using Xunit;
 global using static Caravel.Core.UnitTests.Extensions.VerifyExtensions;
 global using static Caravel.Mermaid.GraphExtensions;

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GetHistory/WhenDirectJourney.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GetHistory/WhenDirectJourney.cs
@@ -1,7 +1,7 @@
 ﻿namespace Caravel.Core.UnitTests.Tests.GetHistory;
 
 [Trait(TestType, Unit)]
-[Trait(Feature, FeatureNavigation)]
+[Trait(Feature, FeatureNodeAction)]
 public class WhenDirectJourney
 {
     [Fact(DisplayName = "History shows only shortest path to 5 Nodes on 5")]
@@ -122,10 +122,8 @@ public class WhenDirectJourney
             .Done();
 
         var journey = builder.Build();
-        // csharpier-ignore
-        var pastJourney = await journey
-            .GotoAsync<NodeSpy5>()
-            .GotoAsync<NodeSpy1>();
+        //csharpier-ignore
+        var pastJourney = await journey.GotoAsync<NodeSpy5>().GotoAsync<NodeSpy1>();
 
         // Act
         var sut = await pastJourney.ToMermaidSequenceDiagram(true);

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/Navigation/OnChainedNavigations/ThrowsException.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/Navigation/OnChainedNavigations/ThrowsException.cs
@@ -44,10 +44,10 @@ public class ThrowsException
             .WithMessage(
                 "Multiple IEdge with the same origin,"
                     + " neighbor and weight detected "
-                    + "('Caravel.Tests.Fixtures.NodeSpies.NodeSpy2"
-                    + " -->|1| Caravel.Tests.Fixtures.NodeSpies.NodeSpy3;"
-                    + "Caravel.Tests.Fixtures.NodeSpies.NodeSpy2 "
-                    + "-->|2| Caravel.Tests.Fixtures.NodeSpies.NodeSpy4')."
+                    + "('Caravel.Tests.Fixtures.NodeSpy2"
+                    + " -->|1| Caravel.Tests.Fixtures.NodeSpy3;"
+                    + "Caravel.Tests.Fixtures.NodeSpy2 "
+                    + "-->|2| Caravel.Tests.Fixtures.NodeSpy4')."
             );
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/Navigation/OnSingleNavigation/ThrowsException.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/Navigation/OnSingleNavigation/ThrowsException.cs
@@ -39,10 +39,10 @@ public class ThrowsException
             .WithMessage(
                 "Multiple IEdge with the same origin,"
                     + " neighbor and weight detected "
-                    + "('Caravel.Tests.Fixtures.NodeSpies.NodeSpy1"
-                    + " -->|1| Caravel.Tests.Fixtures.NodeSpies.NodeSpy2;"
-                    + "Caravel.Tests.Fixtures.NodeSpies.NodeSpy1 "
-                    + "-->|2| Caravel.Tests.Fixtures.NodeSpies.NodeSpy3')."
+                    + "('Caravel.Tests.Fixtures.NodeSpy1"
+                    + " -->|1| Caravel.Tests.Fixtures.NodeSpy2;"
+                    + "Caravel.Tests.Fixtures.NodeSpy1 "
+                    + "-->|2| Caravel.Tests.Fixtures.NodeSpy3')."
             );
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/AllowsToMergeLocalAndJourneyCancellationTokens.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/AllowsToMergeLocalAndJourneyCancellationTokens.cs
@@ -106,7 +106,7 @@ public sealed class AllowsToMergeLocalAndJourneyCancellationTokens : IDisposable
         // Assert
         journey.JourneyCancellationToken.IsCancellationRequested.Should().BeFalse();
         _localTokenSource30mins.IsCancellationRequested.Should().BeFalse();
-        var result = await sut.ToMermaidSequenceDiagram();
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/AllowsToMergeLocalAndJourneyCancellationTokens_Snapshots/Test3.When_journey_CancellationToken_and_local_are_CancellationToken.None.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/AllowsToMergeLocalAndJourneyCancellationTokens_Snapshots/Test3.When_journey_CancellationToken_and_local_are_CancellationToken.None.verified.mmd
@@ -1,2 +1,3 @@
 ﻿sequenceDiagram
+NodeSpy1->>NodeSpy1:0<br>Journey.DoAsync
 NodeSpy1->>NodeSpy2:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
@@ -1,11 +1,11 @@
-﻿namespace Caravel.Core.UnitTests.Tests.NodeAction.BetweenNavigations;
+﻿namespace Caravel.Core.UnitTests.Tests.NodeAction.BeforeAnyNavigation;
 
 [Trait(TestType, Unit)]
 [Trait(Feature, FeatureNodeAction)]
 [Trait(Domain, NodeDomain)]
-public class DoesNotChangeTheCurrentNode
+public class ChangeTheCurrentNode
 {
-    [Fact(DisplayName = "When action is done on current node")]
+    [Fact(DisplayName = "When action returns a different node")]
     public async Task Test1()
     {
         // Arrange
@@ -20,11 +20,12 @@ public class DoesNotChangeTheCurrentNode
             .Done();
 
         var journey = builder.Build();
+        var map = builder.Map;
+        ArgumentNullException.ThrowIfNull(map);
 
         // Act
         var sut = await journey
-            .GotoAsync<NodeSpy2>()
-            .DoAsync<NodeSpy2>((node, ct) => Task.FromResult(node))
+            .DoAsync<NodeSpy1, NodeSpy2>((node, ct) => Task.FromResult(map.NodeSpy2))
             .GotoAsync<NodeSpy3>();
 
         // Assert

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
@@ -32,4 +32,32 @@ public class ChangeTheCurrentNode
         var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
+
+    [Fact(DisplayName = "When action (with journey) returns a different node")]
+    public async Task Test2()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<NodeSpy1>()
+            .WithEdge<NodeSpy2>()
+            .Done()
+            .AddNode<NodeSpy2>()
+            .WithEdge<NodeSpy3>()
+            .Done()
+            .AddNode<NodeSpy3>()
+            .Done();
+
+        var journey = builder.Build();
+        var map = builder.Map;
+        ArgumentNullException.ThrowIfNull(map);
+
+        // Act
+        var sut = await journey
+            .DoAsync<NodeSpy1, NodeSpy2>((journey, node, ct) => Task.FromResult(map.NodeSpy2))
+            .GotoAsync<NodeSpy3>();
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
+        await result.VerifyMermaidMarkdownAsync();
+    }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
@@ -21,7 +21,6 @@ public class ChangeTheCurrentNode
 
         var journey = builder.Build();
         var map = builder.Map;
-        ArgumentNullException.ThrowIfNull(map);
 
         // Act
         var sut = await journey
@@ -49,7 +48,6 @@ public class ChangeTheCurrentNode
 
         var journey = builder.Build();
         var map = builder.Map;
-        ArgumentNullException.ThrowIfNull(map);
 
         // Act
         var sut = await journey

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+NodeSpy1->>NodeSpy2:0<br>Journey.DoAsync
+NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode_Snapshots/Test2.When_action_(with_journey)_returns_a_different_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode_Snapshots/Test2.When_action_(with_journey)_returns_a_different_node.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+NodeSpy1->>NodeSpy2:0<br>Journey.DoAsync
+NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode.cs
@@ -28,7 +28,7 @@ public class DoesNotChangeTheCurrentNode
             .GotoAsync<NodeSpy3>();
 
         // Assert
-        var result = await sut.ToMermaidSequenceDiagram();
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode.cs
@@ -31,4 +31,31 @@ public class DoesNotChangeTheCurrentNode
         var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
+
+    [Fact(DisplayName = "When action (with journey) is done on current node")]
+    public async Task Test2()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<NodeSpy1>()
+            .WithEdge<NodeSpy2>()
+            .Done()
+            .AddNode<NodeSpy2>()
+            .WithEdge<NodeSpy3>()
+            .Done()
+            .AddNode<NodeSpy3>()
+            .Done();
+
+        var journey = builder.Build();
+
+        // Act
+        var sut = await journey
+            .DoAsync<NodeSpy1>((journey, node, ct) => Task.FromResult(node))
+            .GotoAsync<NodeSpy2>()
+            .GotoAsync<NodeSpy3>();
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
+        await result.VerifyMermaidMarkdownAsync();
+    }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
@@ -1,3 +1,4 @@
 ﻿sequenceDiagram
+NodeSpy1->>NodeSpy1:0<br>Journey.DoAsync
 NodeSpy1->>NodeSpy2:0
 NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode_Snapshots/Test2.When_action_(with_journey)_is_done_on_current_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/DoesNotChangeTheCurrentNode_Snapshots/Test2.When_action_(with_journey)_is_done_on_current_node.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+NodeSpy1->>NodeSpy1:0<br>Journey.DoAsync
+NodeSpy1->>NodeSpy2:0
+NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/HasDefaultJourneyAndLocalCancellationTokensToNone.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/HasDefaultJourneyAndLocalCancellationTokensToNone.cs
@@ -41,7 +41,7 @@ public sealed class HasDefaultJourneyAndLocalCancellationTokensToNone : IDisposa
         // Assert
         journey.JourneyCancellationToken.IsCancellationRequested.Should().BeFalse();
         _localTokenSource30mins.IsCancellationRequested.Should().BeFalse();
-        var result = await sut.ToMermaidSequenceDiagram();
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/HasDefaultJourneyAndLocalCancellationTokensToNone_Snapshots/Test1.When_journey_CancellationToken_and_local_are_default.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/HasDefaultJourneyAndLocalCancellationTokensToNone_Snapshots/Test1.When_journey_CancellationToken_and_local_are_default.verified.mmd
@@ -1,2 +1,3 @@
 ﻿sequenceDiagram
+NodeSpy1->>NodeSpy1:0<br>Journey.DoAsync
 NodeSpy1->>NodeSpy2:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/AllowsToMergeLocalAndJourneyCancellationTokens.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/AllowsToMergeLocalAndJourneyCancellationTokens.cs
@@ -118,7 +118,7 @@ public sealed class AllowsToMergeLocalAndJourneyCancellationTokens : IDisposable
         // Assert
         journey.JourneyCancellationToken.IsCancellationRequested.Should().BeFalse();
         _localTokenSource30mins.IsCancellationRequested.Should().BeFalse();
-        var result = await sut.ToMermaidSequenceDiagram();
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/AllowsToMergeLocalAndJourneyCancellationTokens_Snapshots/Test3.When_journey_CancellationToken_and_local_are_CancellationToken.None.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/AllowsToMergeLocalAndJourneyCancellationTokens_Snapshots/Test3.When_journey_CancellationToken_and_local_are_CancellationToken.None.verified.mmd
@@ -1,3 +1,4 @@
 ﻿sequenceDiagram
 NodeSpy1->>NodeSpy2:0
+NodeSpy2->>NodeSpy2:0<br>Journey.DoAsync
 NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
@@ -27,7 +27,6 @@ public class ChangeTheCurrentNode
 
         var journey = builder.Build();
         var map = builder.Map;
-        ArgumentNullException.ThrowIfNull(map);
 
         // Act
         var sut = await journey

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
@@ -3,9 +3,9 @@
 [Trait(TestType, Unit)]
 [Trait(Feature, FeatureNodeAction)]
 [Trait(Domain, NodeDomain)]
-public class DoesNotChangeTheCurrentNode
+public class ChangeTheCurrentNode
 {
-    [Fact(DisplayName = "When action is done on current node")]
+    [Fact(DisplayName = "When action returns a different node")]
     public async Task Test1()
     {
         // Arrange
@@ -17,15 +17,20 @@ public class DoesNotChangeTheCurrentNode
             .WithEdge<NodeSpy3>()
             .Done()
             .AddNode<NodeSpy3>()
+            .WithEdge<NodeSpy4>()
+            .Done()
+            .AddNode<NodeSpy4>()
             .Done();
 
         var journey = builder.Build();
+        var map = builder.Map;
+        ArgumentNullException.ThrowIfNull(map);
 
         // Act
         var sut = await journey
             .GotoAsync<NodeSpy2>()
-            .DoAsync<NodeSpy2>((node, ct) => Task.FromResult(node))
-            .GotoAsync<NodeSpy3>();
+            .DoAsync<NodeSpy2, NodeSpy3>((node, ct) => Task.FromResult(map.NodeSpy3))
+            .GotoAsync<NodeSpy4>();
 
         // Assert
         var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
@@ -20,6 +20,9 @@ public class ChangeTheCurrentNode
             .WithEdge<NodeSpy4>()
             .Done()
             .AddNode<NodeSpy4>()
+            .WithEdge<NodeSpy5>()
+            .Done()
+            .AddNode<NodeSpy5>()
             .Done();
 
         var journey = builder.Build();
@@ -30,7 +33,8 @@ public class ChangeTheCurrentNode
         var sut = await journey
             .GotoAsync<NodeSpy2>()
             .DoAsync<NodeSpy2, NodeSpy3>((node, ct) => Task.FromResult(map.NodeSpy3))
-            .GotoAsync<NodeSpy4>();
+            .DoAsync<NodeSpy3, NodeSpy4>((journey, node, ct) => Task.FromResult(map.NodeSpy4))
+            .GotoAsync<NodeSpy5>();
 
         // Assert
         var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
@@ -1,4 +1,5 @@
 ﻿sequenceDiagram
 NodeSpy1->>NodeSpy2:0
 NodeSpy2->>NodeSpy3:0<br>Journey.DoAsync
-NodeSpy3->>NodeSpy4:0
+NodeSpy3->>NodeSpy4:0<br>Journey.DoAsync
+NodeSpy4->>NodeSpy5:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+NodeSpy1->>NodeSpy2:0
+NodeSpy2->>NodeSpy3:0<br>Journey.DoAsync
+NodeSpy3->>NodeSpy4:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode.cs
@@ -25,6 +25,7 @@ public class DoesNotChangeTheCurrentNode
         var sut = await journey
             .GotoAsync<NodeSpy2>()
             .DoAsync<NodeSpy2>((node, ct) => Task.FromResult(node))
+            .DoAsync<NodeSpy2>((journey, node, ct) => Task.FromResult(node))
             .GotoAsync<NodeSpy3>();
 
         // Assert

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
@@ -1,3 +1,4 @@
 ﻿sequenceDiagram
 NodeSpy1->>NodeSpy2:0
+NodeSpy2->>NodeSpy2:0<br>Journey.DoAsync
 NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/DoesNotChangeTheCurrentNode_Snapshots/Test1.When_action_is_done_on_current_node.verified.mmd
@@ -1,4 +1,5 @@
 ﻿sequenceDiagram
 NodeSpy1->>NodeSpy2:0
 NodeSpy2->>NodeSpy2:0<br>Journey.DoAsync
+NodeSpy2->>NodeSpy2:0<br>Journey.DoAsync
 NodeSpy2->>NodeSpy3:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/HasDefaultJourneyAndLocalCancellationTokensToNone.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/HasDefaultJourneyAndLocalCancellationTokensToNone.cs
@@ -45,7 +45,7 @@ public sealed class HasDefaultJourneyAndLocalCancellationTokensToNone : IDisposa
         // Assert
         journey.JourneyCancellationToken.IsCancellationRequested.Should().BeFalse();
         _localTokenSource30mins.IsCancellationRequested.Should().BeFalse();
-        var result = await sut.ToMermaidSequenceDiagram();
+        var result = await sut.ToMermaidSequenceDiagram(isDescriptionDisplayed: true);
         await result.VerifyMermaidMarkdownAsync();
     }
 }

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/HasDefaultJourneyAndLocalCancellationTokensToNone_Snapshots/Test1.When_journey_CancellationToken_and_local_are_default.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/HasDefaultJourneyAndLocalCancellationTokensToNone_Snapshots/Test1.When_journey_CancellationToken_and_local_are_default.verified.mmd
@@ -1,3 +1,4 @@
 ﻿sequenceDiagram
 NodeSpy1->>NodeSpy2:0
+NodeSpy2->>NodeSpy2:0<br>Journey.DoAsync
 NodeSpy2->>NodeSpy3:0


### PR DESCRIPTION
- Add DoAsync<TCurrent, TOut>() to chain action and navigation when the action returns another node (e.g. in UI testing, action of login on the login page, will open the main page next).
- Move IJourney.DoAsync<TCurrent>()  to extension method to avoid extra implementation.
- Add a Map to JourneyBuilder to resolve returned Node instance in DoAsync tests.