### PR TITLE
Ease cast of IJourney

### DIFF
--- a/src/Caravel.Abstractions/IJourney.cs
+++ b/src/Caravel.Abstractions/IJourney.cs
@@ -6,11 +6,13 @@ public interface IJourney
     IGraph Graph { get; }
     INode CurrentNode { get; }
 
-    Task<IEnumerable<IJourneyLeg>> GetCompletedJourneyLegsAsync(
+    public Task<IEnumerable<IJourneyLeg>> GetCompletedJourneyLegsAsync(
         CancellationToken cancellationToken
     );
 
-    Task<IJourney> GotoAsync<TDestination>(
+    public TJourney OfType<TJourney>();
+
+    public Task<IJourney> GotoAsync<TDestination>(
         IWaypoints waypoints,
         IExcludedNodes excludeNodes,
         CancellationToken localCancellationToken

--- a/src/Caravel.Core/InMemoryJourney.cs
+++ b/src/Caravel.Core/InMemoryJourney.cs
@@ -4,7 +4,7 @@ using Caravel.Abstractions.Events;
 
 namespace Caravel.Core;
 
-public sealed class InMemoryJourney : Journey
+public class InMemoryJourney : Journey
 {
     public InMemoryJourney(
         INode current,
@@ -16,7 +16,7 @@ public sealed class InMemoryJourney : Journey
 
     public ConcurrentQueue<IJourneyLegEvent> LegEvents { get; init; } = [];
 
-    public override Task<IEnumerable<IJourneyLeg>> GetCompletedJourneyLegsAsync(
+    public sealed override Task<IEnumerable<IJourneyLeg>> GetCompletedJourneyLegsAsync(
         CancellationToken cancellationToken = default
     )
     {
@@ -29,7 +29,7 @@ public sealed class InMemoryJourney : Journey
         return Task.FromResult<IEnumerable<IJourneyLeg>>(legArray);
     }
 
-    public override Task PublishOnJourneyLegCompletedAsync(
+    public sealed override Task PublishOnJourneyLegCompletedAsync(
         IJourneyLegCompletedEvent journeyLegCompletedEvent,
         CancellationToken cancellationToken
     )
@@ -41,12 +41,12 @@ public sealed class InMemoryJourney : Journey
         return Task.CompletedTask;
     }
 
-    public override Task PublishOnJourneyLegStartedAsync(
+    public sealed override Task PublishOnJourneyLegStartedAsync(
         IJourneyLegStartedEvent journeyLegStartedEvent,
         CancellationToken cancellationToken
     ) => PublishJourneyLegEventAsync(journeyLegStartedEvent, cancellationToken);
 
-    public override Task PublishOnJourneyLegUpdatedAsync(
+    public sealed override Task PublishOnJourneyLegUpdatedAsync(
         IJourneyLegUpdatedEvent journeyLegUpdatedEvent,
         CancellationToken cancellationToken
     ) => PublishJourneyLegEventAsync(journeyLegUpdatedEvent, cancellationToken);

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -31,6 +31,18 @@ public abstract class Journey : IJourney, IJourneyLegPublisher
     public CancellationToken JourneyCancellationToken { get; }
     public Guid Id { get; init; } = Guid.CreateVersion7();
 
+    public TJourney OfType<TJourney>()
+    {
+        if (this is TJourney journey)
+        {
+            return journey;
+        }
+
+        throw new InvalidCastException(
+            $"Could not cast '{this.GetType()}' to '{typeof(TJourney)}'."
+        );
+    }
+
     public async Task<IJourney> GotoAsync<TDestination>(
         IWaypoints waypoints,
         IExcludedNodes excludeNodes,

--- a/test/Caravel.Tests.Fixtures/SmartJourney.cs
+++ b/test/Caravel.Tests.Fixtures/SmartJourney.cs
@@ -1,0 +1,21 @@
+﻿using Caravel.Abstractions;
+using Caravel.Core;
+
+namespace Caravel.Tests.Fixtures;
+
+public sealed class SmartJourney : InMemoryJourney
+{
+    public SmartJourney(
+        INode current,
+        IGraph graph,
+        TimeProvider timeProvider,
+        Map map,
+        CancellationToken journeyCancellationToken
+    )
+        : base(current, graph, timeProvider, journeyCancellationToken)
+    {
+        Map = map;
+    }
+
+    public Map Map { get; init; }
+}

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BeforeAnyNavigation/ChangeTheCurrentNode.cs
@@ -48,10 +48,13 @@ public class ChangeTheCurrentNode
 
         var journey = builder.Build();
         var map = builder.Map;
-
         // Act
+        // csharpier-ignore
         var sut = await journey
-            .DoAsync<NodeSpy1, NodeSpy2>((journey, node, ct) => Task.FromResult(map.NodeSpy2))
+            .DoAsync<NodeSpy1, NodeSpy2>(
+                (journey, node, ct)
+                => Task.FromResult(journey.OfType<SmartJourney>().Map.NodeSpy2)
+            )
             .GotoAsync<NodeSpy3>();
 
         // Assert

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/BetweenNavigations/ChangeTheCurrentNode.cs
@@ -27,12 +27,15 @@ public class ChangeTheCurrentNode
 
         var journey = builder.Build();
         var map = builder.Map;
-
         // Act
+        // csharpier-ignore
         var sut = await journey
             .GotoAsync<NodeSpy2>()
             .DoAsync<NodeSpy2, NodeSpy3>((node, ct) => Task.FromResult(map.NodeSpy3))
-            .DoAsync<NodeSpy3, NodeSpy4>((journey, node, ct) => Task.FromResult(map.NodeSpy4))
+            .DoAsync<NodeSpy3, NodeSpy4>(
+                (journey, node, ct)
+                => Task.FromResult(journey.OfType<SmartJourney>().Map.NodeSpy4)
+            )
             .GotoAsync<NodeSpy5>();
 
         // Assert


### PR DESCRIPTION
* Add IJourney.OfType<TJourney> to ease the cast of Journey with contextual implementation (map, state machine, context, etc).
* Unsealed class InMemoryJourney but keep the IJourneyLegPublisher implementation sealed by methods.