### PR TITLE
Change Journey and InMemoryJourney methods visibility

### DIFF
--- a/src/Caravel.Core/InMemoryJourney.cs
+++ b/src/Caravel.Core/InMemoryJourney.cs
@@ -29,7 +29,7 @@ public class InMemoryJourney : Journey
         return Task.FromResult<IEnumerable<IJourneyLeg>>(legArray);
     }
 
-    public sealed override Task PublishOnJourneyLegCompletedAsync(
+    protected override Task PublishOnJourneyLegCompletedAsync(
         IJourneyLegCompletedEvent journeyLegCompletedEvent,
         CancellationToken cancellationToken
     )
@@ -41,12 +41,12 @@ public class InMemoryJourney : Journey
         return Task.CompletedTask;
     }
 
-    public sealed override Task PublishOnJourneyLegStartedAsync(
+    protected override Task PublishOnJourneyLegStartedAsync(
         IJourneyLegStartedEvent journeyLegStartedEvent,
         CancellationToken cancellationToken
     ) => PublishJourneyLegEventAsync(journeyLegStartedEvent, cancellationToken);
 
-    public sealed override Task PublishOnJourneyLegUpdatedAsync(
+    protected override Task PublishOnJourneyLegUpdatedAsync(
         IJourneyLegUpdatedEvent journeyLegUpdatedEvent,
         CancellationToken cancellationToken
     ) => PublishJourneyLegEventAsync(journeyLegUpdatedEvent, cancellationToken);

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -199,17 +199,32 @@ public abstract class Journey : IJourney, IJourneyLegPublisher
         throw new UnexpectedNodeException(CurrentNode.GetType(), typeof(TCurrentNode));
     }
 
-    public abstract Task PublishOnJourneyLegCompletedAsync(
+    Task IJourneyLegPublisher.PublishOnJourneyLegCompletedAsync(
+        IJourneyLegCompletedEvent journeyLegCompletedEvent,
+        CancellationToken cancellationToken
+    ) => PublishOnJourneyLegCompletedAsync(journeyLegCompletedEvent, cancellationToken);
+
+    Task IJourneyLegPublisher.PublishOnJourneyLegStartedAsync(
+        IJourneyLegStartedEvent journeyLegStartedEvent,
+        CancellationToken cancellationToken
+    ) => PublishOnJourneyLegStartedAsync(journeyLegStartedEvent, cancellationToken);
+
+    Task IJourneyLegPublisher.PublishOnJourneyLegUpdatedAsync(
+        IJourneyLegUpdatedEvent journeyLegUpdatedEvent,
+        CancellationToken cancellationToken
+    ) => PublishOnJourneyLegUpdatedAsync(journeyLegUpdatedEvent, cancellationToken);
+
+    protected abstract Task PublishOnJourneyLegCompletedAsync(
         IJourneyLegCompletedEvent journeyLegCompletedEvent,
         CancellationToken cancellationToken
     );
 
-    public abstract Task PublishOnJourneyLegStartedAsync(
+    protected abstract Task PublishOnJourneyLegStartedAsync(
         IJourneyLegStartedEvent journeyLegStartedEvent,
         CancellationToken cancellationToken
     );
 
-    public abstract Task PublishOnJourneyLegUpdatedAsync(
+    protected abstract Task PublishOnJourneyLegUpdatedAsync(
         IJourneyLegUpdatedEvent journeyLegUpdatedEvent,
         CancellationToken cancellationToken
     );


### PR DESCRIPTION
Make IJourneyLegPublisher methods protected override from InMemoryJourney to allow children to override them without exposing them. 