### PR TITLE
Replace OnNodeOpenedAsync by OnNodeVisitedAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ internal sealed class Node1 : INode
     private static Task<Node3> OpenNode3(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new Node3());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;
@@ -176,11 +176,11 @@ This makes complex routing logic flexible and maintainable.
 
 ### Node Lifecycle Events
 
-When a node is opened, `INode.OnNodeOpenedAsync()` is invoked. This allows for:
+When a node is visited by `Caravel`, `INode.OnNodeVisitedAsync()` is invoked. This allows for:
 
 * Validation (e.g., waiting for prerequisites)
 * Logging or monitoring
-* Dynamic behavior based on node state
+* Dynamic behavior based on node state (e.g., retrying on failure, set a flag on first visit, etc.)
 
 [[↑ top](#caravel)]
 

--- a/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node1.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node1.cs
@@ -21,7 +21,7 @@ internal sealed class Node1 : INode
     private static Task<Node3> OpenNode3(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new Node3());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node2.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node2.cs
@@ -17,7 +17,7 @@ internal sealed class Node2 : INode
     private static Task<Node3> OpenNode3(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new Node3());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node3.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/UnweightedNodes/Node3.cs
@@ -17,7 +17,7 @@ internal sealed class Node3 : INode
     private static Task<Node1> OpenNode1(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new Node1());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode1.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode1.cs
@@ -30,7 +30,7 @@ internal sealed class WeightedNode1 : INode
     private static Task<WeightedNode3> OpenNode3(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new WeightedNode3());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode2.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode2.cs
@@ -23,7 +23,7 @@ internal sealed class WeightedNode2 : INode
     private static Task<WeightedNode3> OpenNode3(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new WeightedNode3());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode3.cs
+++ b/examples/InMemoryJourneyDemo/Nodes/WeightedNodes/WeightedNode3.cs
@@ -22,7 +22,7 @@ internal sealed class WeightedNode3 : INode
     private static Task<WeightedNode1> OpenNode1(IJourney journey, CancellationToken cancellationToken) =>
         Task.FromResult(new WeightedNode1());
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         // Add your own logic
         return Task.CompletedTask;

--- a/examples/PlaywrightDemo/WebSite.Facade/POMs/Pages/BasePage.cs
+++ b/examples/PlaywrightDemo/WebSite.Facade/POMs/Pages/BasePage.cs
@@ -38,7 +38,7 @@ public class BasePage
         return journey.OfType<WebSiteJourney>().Map.GetPOM<TPOM>();
     }
 
-    public async Task OnNodeOpenedAsync(IJourney _, CancellationToken cancellationToken)
+    public async Task OnNodeVisitedAsync(IJourney _, CancellationToken cancellationToken)
     {
         await Assertions
             .Expect(PageTitle.TxtTitle)

--- a/src/Caravel.Abstractions/INode.cs
+++ b/src/Caravel.Abstractions/INode.cs
@@ -4,17 +4,17 @@ namespace Caravel.Abstractions;
 
 public interface INode
 {
+    /// <summary>
+    /// Get the neighbors <see cref="IEdge"/>.
+    /// </summary>
+    /// <returns>The neighbors</returns>
     public ImmutableHashSet<IEdge> GetEdges();
 
-    // TODO: Document that OnNodeOpenedAsync can be used to log, throw exception or to change a StateMachine.
-    // In the case of the StateMachine, it can be used to dynamically modify the Node.GetEdges().
-    // OnNodeOpenedAsync is always executed before Node.GetEdges().
-
     /// <summary>
-    /// Method called each time a <see cref="INode"/> is opened.
+    /// Method called each time a <see cref="INode"/> is visited by <see cref="Caravel"/>.
     /// </summary>
     /// <param name="journey">The current <see cref="IJourney"/>.</param>
     /// <param name="cancellationToken">The CancellationToken.</param>
     /// <returns>A Task.</returns>
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken);
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken);
 }

--- a/src/Caravel.Core/EnrichedNode.cs
+++ b/src/Caravel.Core/EnrichedNode.cs
@@ -12,6 +12,6 @@ public sealed record EnrichedNode<TNode>(TNode NodeToEnrich, IActionMetaData Act
     public ImmutableHashSet<IEdge> GetEdges() => NodeToEnrich.GetEdges();
 
     /// <inheritdoc cref="INode" />
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken) =>
-        NodeToEnrich.OnNodeOpenedAsync(journey, cancellationToken);
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken) =>
+        NodeToEnrich.OnNodeVisitedAsync(journey, cancellationToken);
 }

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -114,7 +114,7 @@ public class Journey : IJourney
         linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         await CurrentNode
-            .OnNodeOpenedAsync(this, linkedCancellationTokenSource.Token)
+            .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
             .ConfigureAwait(false);
 
         var originType = CurrentNode.GetType();
@@ -160,7 +160,7 @@ public class Journey : IJourney
         linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         await CurrentNode
-            .OnNodeOpenedAsync(this, linkedCancellationTokenSource.Token)
+            .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
             .ConfigureAwait(false);
 
         // Validate the CurrentNode at each steps.
@@ -187,7 +187,7 @@ public class Journey : IJourney
             linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
             await outNode
-                .OnNodeOpenedAsync(this, linkedCancellationTokenSource.Token)
+                .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
             return this;
@@ -289,7 +289,7 @@ public class Journey : IJourney
                 .NeighborNavigator.MoveNext(this, cancellationToken)
                 .ConfigureAwait(false);
 
-            await CurrentNode.OnNodeOpenedAsync(this, cancellationToken).ConfigureAwait(false);
+            await CurrentNode.OnNodeVisitedAsync(this, cancellationToken).ConfigureAwait(false);
 
             journeyLeg.Edges.Enqueue(edge);
             await _journeyLegPublisher
@@ -354,6 +354,6 @@ public class Journey : IJourney
             throw new UnexpectedNodeException(destinationType, CurrentNode.GetType());
         }
 
-        await CurrentNode.OnNodeOpenedAsync(this, cancellationToken).ConfigureAwait(false);
+        await CurrentNode.OnNodeVisitedAsync(this, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/test/Caravel.Tests.Fixtures/NodeSpyBase.cs
+++ b/test/Caravel.Tests.Fixtures/NodeSpyBase.cs
@@ -17,7 +17,7 @@ public class NodeSpyBase : INodeSpy
 
     public ImmutableHashSet<IEdge> GetEdges() => InternalEdges;
 
-    public Task OnNodeOpenedAsync(IJourney journey, CancellationToken cancellationToken)
+    public Task OnNodeVisitedAsync(IJourney journey, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         if (_isOnOpenedSuccess)


### PR DESCRIPTION
OnNodeVisitedAsync is more accurate since the node can be visited more than once when it is already opened.