### PR TITLE
Document extension method CreateEdge<TNeighbor>

### DIFF
--- a/src/Caravel.Abstractions/Configurations/IEdgeFactory.cs
+++ b/src/Caravel.Abstractions/Configurations/IEdgeFactory.cs
@@ -11,5 +11,12 @@ public interface IEdgeFactory
     /// returned from the <see cref="IEdge"/> must contains the same instance than <paramref name="selfNode"/>.</remarks>
     public IEdge CreteSelfEdge(INode selfNode);
 
+    /// <summary>
+    /// Create a <see cref="IEdge"/> with no weight.
+    /// </summary>
+    /// <param name="origin">The point of origin.</param>
+    /// <param name="destination">The point of destination.</param>
+    /// <param name="actionMetaData">The optional <see cref="IActionMetaData"/>.</param>
+    /// <returns>An <see cref="IEdge"/> returning an instance of the <paramref name="destination"/>.</returns>
     public IEdge CreateEdge(INode origin, INode destination, IActionMetaData? actionMetaData);
 }

--- a/src/Caravel.Core/Extensions/INodeExtensions.cs
+++ b/src/Caravel.Core/Extensions/INodeExtensions.cs
@@ -5,14 +5,17 @@ namespace Caravel.Core.Extensions;
 public static class INodeExtensions
 {
     /// <summary>
-    /// Create an <see cref="IEdge"/>.
+    /// Create an <see cref="Edge"/>.
     /// </summary>
     /// <typeparam name="TNeighbor">The type of the neighbor</typeparam>
     /// <param name="origin">The origin <see cref="INode"/>.</param>
     /// <param name="moveNext">The function to move to the neighbor.</param>
     /// <param name="weight">The weight of the <see cref="IEdge"/>.</param>
-    /// <param name="metaData">The metaData of the <see cref="IEdge.NeighborNavigator"/>.</param>
+    /// <param name="metaData">The metaData to add to the <see cref="NeighborNavigator"/>.</param>
     /// <returns>The <see cref="IEdge"/>.</returns>
+    /// <remarks>This helper method used the default <see cref="Edge"/> and <see cref="NeighborNavigator"/>.
+    /// Do not use for custom <see cref="IEdge"/> or <see cref="INeighborNavigator"/>.
+    /// </remarks>
     public static IEdge CreateEdge<TNeighbor>(
         this INode origin,
         Func<IJourney, CancellationToken, Task<TNeighbor>> moveNext,


### PR DESCRIPTION
Explain why CreateEdge<TNeighbor> extension method is not for custom implementation of IEdge since this a helper that do not rely on IEdgeFactory but returns a concrete Edge instance.