### PR TITLE
Add GotoDoAsync extension methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ⚠️**Warning!**  
 > 
-> Caravel is a pre‑release framework.
+> `Caravel` is a pre‑release framework.
 The public API, documentation and internal implementation are still evolving, and breaking changes may occur in future releases.
 
 `Caravel` is a framework that provides an abstraction for creating and navigating graphs. Enabling developers to define relationships between nodes and traverse them efficiently using Dijkstra's algorithm for shortest path calculations.
@@ -153,13 +153,13 @@ Node3->>Node1:0
 
 ### Graph Navigation with Dijkstra Algorithm
 
-Caravel supports the creation of weighted and unweighted graphs through `Caravel.Graph.Dijkstra`. Using Dijkstra's algorithm, it can compute the shortest route from any node to another, making it ideal for applications requiring optimal pathfinding.
+`Caravel` supports the creation of weighted and unweighted graphs through `Caravel.Graph.Dijkstra`. Using Dijkstra's algorithm, it can compute the shortest route from any node to another, making it ideal for applications requiring optimal pathfinding.
 
 [[↑ top](#caravel)]
 
 ### Step-by-Step Node Navigation
 
-With methods like `GotoAsync<TDestination>`, Caravel allows step-by-step navigation through a graph. Each node implements `INode.GetEdges()` to declare its neighbors and transitions, enabling fluent navigation patterns.
+With methods like `GotoAsync<TDestination>`, `Caravel` allows step-by-step navigation through a graph. Each node implements `INode.GetEdges()` to declare its neighbors and transitions, enabling fluent navigation patterns.
 
 [[↑ top](#caravel)]
 
@@ -186,7 +186,9 @@ When a node is visited by `Caravel`, `INode.OnNodeVisitedAsync()` is invoked. Th
 
 ### Contextual Actions in Nodes
 
-Caravel supports executing actions within the context of a node using `DoAsync<TCurrentNode>` or transitioning to another node via `DoAsync<TCurrentNode, TDestination>`. This enables rich workflows with side-effects and dynamic navigation.
+`Caravel` supports executing actions within the context of the current node using `DoAsync<TCurrentNode>` or transitioning to another node via `DoAsync<TCurrentNode, TTargetNode>`. This enables rich workflows with side-effects and dynamic navigation.
+
+`GotoDoAsync<TOriginNode, TTargetNode>` can be used to combine navigation and action in a single step. It navigates to `TOriginNode` and performs the specified action returning `TTargnetNode`. `TTargnetNode` can be the same as `TOriginNode` to perform actions without changing nodes.
 
 [[↑ top](#caravel)]
 
@@ -196,7 +198,7 @@ Each journey has a global timeout (`JourneyCancellationToken`) that applies acro
 
 ### Documentation via Mermaid
 
-Caravel integrates seamlessly with Mermaid.js for documentation:
+`Caravel` integrates seamlessly with Mermaid.js for documentation:
 
 * **Graph Diagrams**: Visualize the entire graph structure.
 * **Sequence Diagrams**: Document navigation flows and action sequences.
@@ -206,7 +208,7 @@ Caravel integrates seamlessly with Mermaid.js for documentation:
 
 ### UI Automation Ready
 
-Caravel is compatible with Page Object Models (POM) and tools like [Playwright](https://playwright.dev/dotnet/), making it suitable for automating UI journeys in web or desktop applications.
+`Caravel` is compatible with Page Object Models (POM) and tools like [Playwright](https://playwright.dev/dotnet/), making it suitable for automating UI journeys in web or desktop applications.
 
 [[↑ top](#caravel)]
 

--- a/src/Caravel.Abstractions/IEnrichedNode.cs
+++ b/src/Caravel.Abstractions/IEnrichedNode.cs
@@ -10,7 +10,7 @@ public interface IEnrichedNode<TNode> : INode
     where TNode : INode
 {
     /// <summary>
-    /// The <see cref="ActionMetaData"/> to add when returns from <see cref="IJourney.DoAsync{TCurrentNode, TNodeOut}(Func{IJourney, TCurrentNode, CancellationToken, Task{TNodeOut}}, CancellationToken)"/>
+    /// The <see cref="ActionMetaData"/> to add when returns from <see cref="IJourney.DoAsync{TCurrentNode, TTargetNode}(Func{IJourney, TCurrentNode, CancellationToken, Task{TTargetNode}}, CancellationToken)"/>
     /// </summary>
     ///
     IActionMetaData ActionMetaData { get; init; }

--- a/src/Caravel.Abstractions/IJourney.cs
+++ b/src/Caravel.Abstractions/IJourney.cs
@@ -29,10 +29,10 @@ public interface IJourney
     )
         where TDestination : INode;
 
-    public Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+    public Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode;
+        where TTargetNode : INode;
 }

--- a/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
@@ -135,23 +135,6 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
-        this Task<IJourney> journeyTask,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
-        CancellationToken scopedCancellationToken = default
-    )
-        where TOriginNode : INode
-        where TTargetNode : INode
-    {
-        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
-        var waypoints = EmptyWaypoints.Create();
-        var excludedWaypoints = EmptyExcludedWaypoints.Create();
-
-        return await journeyTask
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
-            .ConfigureAwait(false);
-    }
-
     /// <summary>
     /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
     /// and then executes <paramref name="func"/> with that node as the context.
@@ -170,9 +153,6 @@ public static partial class JourneyExtensions
     /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
     /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
     /// </param>
-    /// <param name="waypoints">
-    /// The collection of waypoints that the journey must cross to reach <typeparamref name="TOriginNode"/>.
-    /// </param>
     /// <param name="scopedCancellationToken">
     /// A cancellation token that applies only to this method.
     /// </param>
@@ -182,7 +162,51 @@ public static partial class JourneyExtensions
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this Task<IJourney> journeyTask,
         Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+        var waypoints = EmptyWaypoints.Create();
+        var excludedWaypoints = EmptyExcludedWaypoints.Create();
+
+        return await journeyTask
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journeyTask">
+    /// A task that resolves to the <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="waypoints">
+    /// The <see cref="IWaypoints"/> that the journey must cross to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this Task<IJourney> journeyTask,
         IWaypoints waypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode
@@ -192,14 +216,41 @@ public static partial class JourneyExtensions
         var excludedWaypoints = EmptyExcludedWaypoints.Create();
 
         return await journeyTask
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journeyTask">
+    /// A task that resolves to the <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="excludedWaypoints">
+    /// The <see cref="IExcludedWaypoints"/> that the journey must avoid to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this Task<IJourney> journeyTask,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         IExcludedWaypoints excludedWaypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode
@@ -209,15 +260,45 @@ public static partial class JourneyExtensions
         var waypoints = EmptyWaypoints.Create();
 
         return await journeyTask
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journeyTask">
+    /// A task that resolves to the <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="waypoints">
+    /// The <see cref="IWaypoints"/> that the journey must cross to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="excludedWaypoints">
+    /// The <see cref="IExcludedWaypoints"/> that the journey must avoid to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this Task<IJourney> journeyTask,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         IWaypoints waypoints,
         IExcludedWaypoints excludedWaypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode

--- a/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
@@ -1,5 +1,4 @@
 ﻿using Caravel.Abstractions;
-using Caravel.Abstractions.Exceptions;
 
 namespace Caravel.Core.Extensions;
 
@@ -136,11 +135,105 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
-    internal static void ThrowIfNotCurrentNode(this Type current, Type expected)
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
     {
-        if (current != expected)
-        {
-            throw new UnexpectedNodeException(current, expected);
-        }
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+        var waypoints = EmptyWaypoints.Create();
+        var excludedWaypoints = EmptyExcludedWaypoints.Create();
+
+        return await journeyTask
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journeyTask">
+    /// A task that resolves to the <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="waypoints">
+    /// The collection of waypoints that the journey must cross to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IWaypoints waypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+        var excludedWaypoints = EmptyExcludedWaypoints.Create();
+
+        return await journeyTask
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IExcludedWaypoints excludedWaypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+        var waypoints = EmptyWaypoints.Create();
+
+        return await journeyTask
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this Task<IJourney> journeyTask,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IWaypoints waypoints,
+        IExcludedWaypoints excludedWaypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
+        ArgumentNullException.ThrowIfNull(waypoints, nameof(waypoints));
+        ArgumentNullException.ThrowIfNull(excludedWaypoints, nameof(excludedWaypoints));
+        var originType = typeof(TOriginNode);
+        var targetType = typeof(TTargetNode);
+        var journey = await journeyTask.ConfigureAwait(false);
+
+        await journey
+            .GotoAsync(originType, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+
+        return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.Task.cs
@@ -95,13 +95,13 @@ public static partial class JourneyExtensions
             .ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+    public static async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
         this Task<IJourney> journeyTask,
-        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        Func<TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode
+        where TTargetNode : INode
     {
         ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
 
@@ -122,13 +122,13 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+    public static async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
         this Task<IJourney> journeyTask,
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode
+        where TTargetNode : INode
     {
         ArgumentNullException.ThrowIfNull(journeyTask, nameof(journeyTask));
 

--- a/src/Caravel.Core.Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.cs
@@ -112,6 +112,30 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journey">
+    /// The <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this IJourney journey,
         Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
@@ -125,14 +149,41 @@ public static partial class JourneyExtensions
         var excludedWaypoints = EmptyExcludedWaypoints.Create();
 
         return await journey
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journey">
+    /// The <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="waypoints">
+    /// The <see cref="IWaypoints"/> that the journey must cross to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this IJourney journey,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         IWaypoints waypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode
@@ -142,14 +193,41 @@ public static partial class JourneyExtensions
         var excludedWaypoints = EmptyExcludedWaypoints.Create();
 
         return await journey
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journey">
+    /// The <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="excludedWaypoints">
+    /// The <see cref="IExcludedWaypoints"/> that the journey must avoid to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this IJourney journey,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         IExcludedWaypoints excludedWaypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode
@@ -158,15 +236,45 @@ public static partial class JourneyExtensions
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
         var waypoints = EmptyWaypoints.Create();
         return await journey
-            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .GotoDoAsync(waypoints, excludedWaypoints, func, scopedCancellationToken)
             .ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Moves the current <see cref="IJourney"/> to the specified <typeparamref name="TOriginNode"/>
+    /// and then executes <paramref name="func"/> with that node as the context.
+    /// </summary>
+    /// <typeparam name="TOriginNode">
+    /// The type of node that the journey is navigated to before <paramref name="func"/> is invoked.
+    /// </typeparam>
+    /// <typeparam name="TTargetNode">
+    /// The type of node that <paramref name="func"/> returns.
+    /// It may be the same as <typeparamref name="TOriginNode"/> or a different node.
+    /// </typeparam>
+    /// <param name="journey">
+    /// The <see cref="IJourney"/> to be operated on.
+    /// </param>
+    /// <param name="waypoints">
+    /// The <see cref="IWaypoints"/> that the journey must cross to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="excludedWaypoints">
+    /// The <see cref="IExcludedWaypoints"/> that the journey must avoid to reach <typeparamref name="TOriginNode"/>.
+    /// </param>
+    /// <param name="func">
+    /// A function that runs in the context of the node reached by <typeparamref name="TOriginNode"/>.
+    /// The function receives the journey, the reached node, and a cancellation token, and returns a node of type <typeparamref name="TTargetNode"/>.
+    /// </param>
+    /// <param name="scopedCancellationToken">
+    /// A cancellation token that applies only to this method.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="IJourney"/> instance, now positioned at the node returned by <paramref name="func"/>.
+    /// </returns>
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this IJourney journey,
-        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         IWaypoints waypoints,
         IExcludedWaypoints excludedWaypoints,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TOriginNode : INode

--- a/src/Caravel.Core.Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.cs
@@ -84,17 +84,17 @@ public static partial class JourneyExtensions
             .ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+    public static async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
         this IJourney journey,
-        Func<TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        Func<TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode
+        where TTargetNode : INode
     {
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
         return await journey
-            .DoAsync<TCurrentNode, TNodeOut>(
+            .DoAsync<TCurrentNode, TTargetNode>(
                 (_, node, token) => func(node, token),
                 scopedCancellationToken
             )
@@ -112,13 +112,13 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
+    public static async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
         this IJourney journey,
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode
+        where TTargetNode : INode
     {
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);

--- a/src/Caravel.Core.Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.cs
@@ -112,18 +112,6 @@ public static partial class JourneyExtensions
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
 
-    public static async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
-        this IJourney journey,
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TTargetNode>> func,
-        CancellationToken scopedCancellationToken = default
-    )
-        where TCurrentNode : INode
-        where TTargetNode : INode
-    {
-        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
-        return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
-    }
-
     public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
         this IJourney journey,
         Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,

--- a/src/Caravel.Core.Extensions/JourneyExtensions.cs
+++ b/src/Caravel.Core.Extensions/JourneyExtensions.cs
@@ -123,4 +123,77 @@ public static partial class JourneyExtensions
         ArgumentNullException.ThrowIfNull(journey, nameof(journey));
         return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
     }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this IJourney journey,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        var waypoints = EmptyWaypoints.Create();
+        var excludedWaypoints = EmptyExcludedWaypoints.Create();
+
+        return await journey
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this IJourney journey,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IWaypoints waypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        var excludedWaypoints = EmptyExcludedWaypoints.Create();
+
+        return await journey
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this IJourney journey,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IExcludedWaypoints excludedWaypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        var waypoints = EmptyWaypoints.Create();
+        return await journey
+            .GotoDoAsync(func, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public static async Task<IJourney> GotoDoAsync<TOriginNode, TTargetNode>(
+        this IJourney journey,
+        Func<IJourney, TOriginNode, CancellationToken, Task<TTargetNode>> func,
+        IWaypoints waypoints,
+        IExcludedWaypoints excludedWaypoints,
+        CancellationToken scopedCancellationToken = default
+    )
+        where TOriginNode : INode
+        where TTargetNode : INode
+    {
+        ArgumentNullException.ThrowIfNull(journey, nameof(journey));
+        ArgumentNullException.ThrowIfNull(waypoints, nameof(waypoints));
+        ArgumentNullException.ThrowIfNull(excludedWaypoints, nameof(excludedWaypoints));
+        var originType = typeof(TOriginNode);
+        var targetType = typeof(TTargetNode);
+
+        await journey
+            .GotoAsync(originType, waypoints, excludedWaypoints, scopedCancellationToken)
+            .ConfigureAwait(false);
+
+        return await journey.DoAsync(func, scopedCancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -142,12 +142,12 @@ public class Journey : IJourney
         return this;
     }
 
-    public async Task<IJourney> DoAsync<TCurrentNode, TNodeOut>(
-        Func<IJourney, TCurrentNode, CancellationToken, Task<TNodeOut>> func,
+    public async Task<IJourney> DoAsync<TCurrentNode, TTargetNode>(
+        Func<IJourney, TCurrentNode, CancellationToken, Task<TTargetNode>> func,
         CancellationToken scopedCancellationToken = default
     )
         where TCurrentNode : INode
-        where TNodeOut : INode
+        where TTargetNode : INode
     {
         // Prevent setting starting node once the journey is started
         _isJourneyStarted = true;
@@ -169,15 +169,15 @@ public class Journey : IJourney
             var funcNode = await func(this, current, linkedCancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
-            (var outNode, var actionMetaData) = GetNodeIfWrapped(funcNode);
+            (var targetNode, var actionMetaData) = GetNodeIfWrapped(funcNode);
 
             // Change the current node.
-            CurrentNode = outNode;
+            CurrentNode = targetNode;
 
             // Ensure the navigation from DoAsync is registered as JourneyLeg.
             var doJourneyLeg = await AddDoAsyncToJourneyLegAsync(
                     current,
-                    outNode,
+                    targetNode,
                     Id,
                     actionMetaData,
                     linkedCancellationTokenSource.Token
@@ -186,7 +186,7 @@ public class Journey : IJourney
 
             linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-            await outNode
+            await targetNode
                 .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
                 .ConfigureAwait(false);
 
@@ -196,10 +196,11 @@ public class Journey : IJourney
         throw new UnexpectedNodeException(CurrentNode.GetType(), typeof(TCurrentNode));
     }
 
-    private static (INode outNode, IActionMetaData? actionMetaData) GetNodeIfWrapped<TNodeOut>(
-        TNodeOut funcNode
-    )
-        where TNodeOut : INode
+    private static (
+        INode targetNode,
+        IActionMetaData? actionMetaData
+    ) GetNodeIfWrapped<TTargetNode>(TTargetNode funcNode)
+        where TTargetNode : INode
     {
         ArgumentNullException.ThrowIfNull(funcNode, nameof(funcNode));
 
@@ -303,7 +304,7 @@ public class Journey : IJourney
 
     private async Task<IJourneyLeg> AddDoAsyncToJourneyLegAsync(
         INode currentNode,
-        INode nodeOut,
+        INode targetNode,
         Guid journeyId,
         IActionMetaData? actionMetaData,
         CancellationToken linkedCancellationToken
@@ -316,7 +317,7 @@ public class Journey : IJourney
 
         var journeyLeg = _journeyLegFactory.CreateJourneyLeg(
             currentNode,
-            nodeOut,
+            targetNode,
             journeyId,
             Graph.RouteFactory,
             Graph.EdgeFactory,
@@ -330,7 +331,7 @@ public class Journey : IJourney
             )
             .ConfigureAwait(false);
 
-        await CompleteJourneyLegAsync(nodeOut.GetType(), journeyLeg, linkedCancellationToken)
+        await CompleteJourneyLegAsync(targetNode.GetType(), journeyLeg, linkedCancellationToken)
             .ConfigureAwait(false);
 
         return journeyLeg;

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -48,7 +48,7 @@ public class Journey : IJourney
 
     public INode CurrentNode { get; private set; }
     public IGraph Graph { get; init; }
-    public CancellationToken JourneyCancellationToken { get; }
+    public CancellationToken JourneyCancellationToken { get; init; }
     public Guid Id { get; init; } = Guid.NewGuid();
     public IJourneyLegReader JourneyLegReader { get; init; }
 

--- a/test/UnitTests/Caravel.Core.UnitTests/Caravel.Core.UnitTests.csproj
+++ b/test/UnitTests/Caravel.Core.UnitTests/Caravel.Core.UnitTests.csproj
@@ -42,5 +42,6 @@
       <Folder Include="Tests\Navigation\Atomic\AtomicGotoDestination_Snapshots\" />
       <Folder Include="Tests\Navigation\Atomic\AtomicHasEmptySequenceDiagram_Snapshots\" />
       <Folder Include="Tests\Navigation\Chained\ChainedGotoDestination_Snapshots\" />
+      <Folder Include="Tests\NodeAction\Chained\ChainedChangesTheCurrentNode_Snapshots\" />
     </ItemGroup>
 </Project>

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo.cs
@@ -1,0 +1,309 @@
+﻿namespace Caravel.Core.UnitTests.Tests.GotoDo.Atomic;
+
+[Trait(TestType, Unit)]
+[Trait(Feature, FeatureNodeAction)]
+[Trait(Domain, NodeDomain)]
+public sealed class AtomicGotoDo : IDisposable
+{
+    private readonly CancellationTokenSource _localTokenSource30mins;
+
+    public AtomicGotoDo()
+    {
+        _localTokenSource30mins = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+    }
+
+    public void Dispose()
+    {
+        _localTokenSource30mins?.Dispose();
+    }
+
+    [Fact(DisplayName = "When current, origin and target is the same node")]
+    public async Task Test1()
+    {
+        // Arrange
+        var builder = new JourneyBuilder().AddNode<Node1>().Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node1, Node1>(
+            (journey, node1, ct) =>
+            {
+                return Task.FromResult(node1);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current, origin and target is the same node is the same, with enriched metadata"
+    )]
+    public async Task Test2()
+    {
+        // Arrange
+        var builder = new JourneyBuilder().AddNode<Node1>().Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node1, EnrichedNode<Node1>>(
+            (journey, node1, ct) =>
+            {
+                var actionMetadata = new ActionMetaData("My custom metadata");
+                var enrichedNode = new EnrichedNode<Node1>(node1, actionMetadata);
+                return Task.FromResult(enrichedNode);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "When current and origin is same node but target is different")]
+    public async Task Test3()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node1, Node2>(
+            (journey, node1, ct) =>
+            {
+                return Task.FromResult(builder.Map.NodeSpy2);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current and origin is same node but target is different, with enriched metadata"
+    )]
+    public async Task Test4()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node1, EnrichedNode<Node2>>(
+            (journey, node1, ct) =>
+            {
+                var actionMetadata = new ActionMetaData("My custom metadata");
+                var enrichedNode = new EnrichedNode<Node2>(builder.Map.NodeSpy2, actionMetadata);
+                return Task.FromResult(enrichedNode);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "When current, origin and target are all different")]
+    public async Task Test5()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node2, Node3>(
+            (journey, node2, ct) =>
+            {
+                return Task.FromResult(builder.Map.NodeSpy3);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current, origin and target are all different, with enriched metadata"
+    )]
+    public async Task Test6()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node2, EnrichedNode<Node3>>(
+            (journey, node2, ct) =>
+            {
+                var actionMetadata = new ActionMetaData("My custom metadata");
+                var enrichedNode = new EnrichedNode<Node3>(builder.Map.NodeSpy3, actionMetadata);
+                return Task.FromResult(enrichedNode);
+            },
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "With waypoints")]
+    public async Task Test7()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+        Waypoints waypoints = [typeof(Node2)];
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node3, Node4>(
+            (journey, node3, ct) =>
+            {
+                return Task.FromResult(builder.Map.NodeSpy4);
+            },
+            waypoints,
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "With excluded waypoints")]
+    public async Task Test8()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node4>(weight: 99)
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .WithEdge<Node5>()
+            .Done()
+            .AddNode<Node5>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Since Node2 has a weight of 99, excluding Node3 validate that we force path on Node2.
+        ExcludedWaypoints excludedWaypoints = [typeof(Node3)];
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node4, Node5>(
+            (journey, node4, ct) =>
+            {
+                return Task.FromResult(builder.Map.NodeSpy5);
+            },
+            excludedWaypoints,
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "With included and excluded waypoints")]
+    public async Task Test9()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node4>(weight: 99)
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .WithEdge<Node5>()
+            .Done()
+            .AddNode<Node5>()
+            .WithEdge<Node6>()
+            .Done()
+            .AddNode<Node6>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Since Node2 has a weight of 99, excluding Node3 validate that we force path on Node2.
+        ExcludedWaypoints excludedWaypoints = [typeof(Node3)];
+        Waypoints waypoints = [typeof(Node4)];
+
+        // Act
+        var sut = await journey.GotoDoAsync<Node5, Node6>(
+            (journey, node5, ct) =>
+            {
+                return Task.FromResult(builder.Map.NodeSpy6);
+            },
+            waypoints,
+            excludedWaypoints,
+            CancellationToken.None
+        );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+}

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo.cs
@@ -209,11 +209,11 @@ public sealed class AtomicGotoDo : IDisposable
 
         // Act
         var sut = await journey.GotoDoAsync<Node3, Node4>(
+            waypoints,
             (journey, node3, ct) =>
             {
                 return Task.FromResult(builder.Map.NodeSpy4);
             },
-            waypoints,
             CancellationToken.None
         );
 
@@ -249,11 +249,11 @@ public sealed class AtomicGotoDo : IDisposable
 
         // Act
         var sut = await journey.GotoDoAsync<Node4, Node5>(
+            excludedWaypoints,
             (journey, node4, ct) =>
             {
                 return Task.FromResult(builder.Map.NodeSpy5);
             },
-            excludedWaypoints,
             CancellationToken.None
         );
 
@@ -293,12 +293,12 @@ public sealed class AtomicGotoDo : IDisposable
 
         // Act
         var sut = await journey.GotoDoAsync<Node5, Node6>(
+            waypoints,
+            excludedWaypoints,
             (journey, node5, ct) =>
             {
                 return Task.FromResult(builder.Map.NodeSpy6);
             },
-            waypoints,
-            excludedWaypoints,
             CancellationToken.None
         );
 

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test1.When_current_origin_and_target_is_the_same_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test1.When_current_origin_and_target_is_the_same_node.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test2.When_current_origin_and_target_is_the_same_node_is_the_same_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test2.When_current_origin_and_target_is_the_same_node_is_the_same_with_enriched_metadata.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test3.When_current_and_origin_is_same_node_but_target_is_different.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test3.When_current_and_origin_is_same_node_but_target_is_different.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node2:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test4.When_current_and_origin_is_same_node_but_target_is_different_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test4.When_current_and_origin_is_same_node_but_target_is_different_with_enriched_metadata.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node2:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test5.When_current_origin_and_target_are_all_different.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test5.When_current_origin_and_target_are_all_different.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test6.When_current_origin_and_target_are_all_different_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test6.When_current_origin_and_target_are_all_different_with_enriched_metadata.verified.mmd
@@ -1,0 +1,3 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test7.With_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test7.With_waypoints.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0
+Node3->>Node4:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test8.With_excluded_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test8.With_excluded_waypoints.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node4:99
+Node4->>Node5:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test9.With_included_and_excluded_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Atomic/AtomicGotoDo_Snapshots/Test9.With_included_and_excluded_waypoints.verified.mmd
@@ -1,0 +1,5 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node4:99
+Node4->>Node5:0
+Node5->>Node6:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
@@ -1,0 +1,353 @@
+﻿namespace Caravel.Core.UnitTests.Tests.GotoDo.Chained;
+
+[Trait(TestType, Unit)]
+[Trait(Feature, FeatureNodeAction)]
+[Trait(Domain, NodeDomain)]
+public sealed class ChainedGotoDo : IDisposable
+{
+    private readonly CancellationTokenSource _localTokenSource30mins;
+
+    public ChainedGotoDo()
+    {
+        _localTokenSource30mins = new CancellationTokenSource(TimeSpan.FromMinutes(30));
+    }
+
+    public void Dispose()
+    {
+        _localTokenSource30mins?.Dispose();
+    }
+
+    [Fact(DisplayName = "When current, origin and target is the same node")]
+    public async Task Test1()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node1, Node1>(
+                (journey, node1, ct) =>
+                {
+                    return Task.FromResult(node1);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current, origin and target is the same node is the same, with enriched metadata"
+    )]
+    public async Task Test2()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node1, EnrichedNode<Node1>>(
+                (journey, node1, ct) =>
+                {
+                    var actionMetadata = new ActionMetaData("My custom metadata");
+                    var enrichedNode = new EnrichedNode<Node1>(node1, actionMetadata);
+                    return Task.FromResult(enrichedNode);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "When current and origin is same node but target is different")]
+    public async Task Test3()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node1, Node2>(
+                (journey, node1, ct) =>
+                {
+                    return Task.FromResult(builder.Map.NodeSpy2);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current and origin is same node but target is different, with enriched metadata"
+    )]
+    public async Task Test4()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node1, EnrichedNode<Node2>>(
+                (journey, node1, ct) =>
+                {
+                    var actionMetadata = new ActionMetaData("My custom metadata");
+                    var enrichedNode = new EnrichedNode<Node2>(
+                        builder.Map.NodeSpy2,
+                        actionMetadata
+                    );
+                    return Task.FromResult(enrichedNode);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "When current, origin and target are all different")]
+    public async Task Test5()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node2>()
+            .GotoDoAsync<Node3, Node4>(
+                (journey, node2, ct) =>
+                {
+                    return Task.FromResult(builder.Map.NodeSpy4);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(
+        DisplayName = "When current, origin and target are all different, with enriched metadata"
+    )]
+    public async Task Test6()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node2>()
+            .GotoDoAsync<Node3, EnrichedNode<Node4>>(
+                (journey, node2, ct) =>
+                {
+                    var actionMetadata = new ActionMetaData("My custom metadata");
+                    var enrichedNode = new EnrichedNode<Node4>(
+                        builder.Map.NodeSpy4,
+                        actionMetadata
+                    );
+                    return Task.FromResult(enrichedNode);
+                },
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    //-------------------------------------------------------------
+
+    [Fact(DisplayName = "With waypoints")]
+    public async Task Test7()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+        Waypoints waypoints = [typeof(Node2)];
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node3, Node4>(
+                (journey, node3, ct) =>
+                {
+                    return Task.FromResult(builder.Map.NodeSpy4);
+                },
+                waypoints,
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "With excluded waypoints")]
+    public async Task Test8()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node4>(weight: 99)
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .WithEdge<Node5>()
+            .Done()
+            .AddNode<Node5>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Since Node2 has a weight of 99, excluding Node3 validate that we force path on Node2.
+        ExcludedWaypoints excludedWaypoints = [typeof(Node3)];
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node4, Node5>(
+                (journey, node1, ct) =>
+                {
+                    return Task.FromResult(builder.Map.NodeSpy5);
+                },
+                excludedWaypoints,
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "With included and excluded waypoints")]
+    public async Task Test9()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node4>(weight: 99)
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .WithEdge<Node5>()
+            .Done()
+            .AddNode<Node5>()
+            .WithEdge<Node6>()
+            .Done()
+            .AddNode<Node6>()
+            .Done();
+
+        var journey = builder.Build(ct: CancellationToken.None);
+
+        // Since Node2 has a weight of 99, excluding Node3 validate that we force path on Node2.
+        ExcludedWaypoints excludedWaypoints = [typeof(Node3)];
+        Waypoints waypoints = [typeof(Node4)];
+
+        // Act
+        var sut = await journey
+            .GotoAsync<Node1>()
+            .GotoDoAsync<Node5, Node6>(
+                (journey, node1, ct) =>
+                {
+                    return Task.FromResult(builder.Map.NodeSpy6);
+                },
+                waypoints,
+                excludedWaypoints,
+                CancellationToken.None
+            );
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+}

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
@@ -223,8 +223,6 @@ public sealed class ChainedGotoDo : IDisposable
         await result.VerifyMermaidMarkdownAsync();
     }
 
-    //-------------------------------------------------------------
-
     [Fact(DisplayName = "With waypoints")]
     public async Task Test7()
     {

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo.cs
@@ -169,7 +169,7 @@ public sealed class ChainedGotoDo : IDisposable
         var sut = await journey
             .GotoAsync<Node2>()
             .GotoDoAsync<Node3, Node4>(
-                (journey, node2, ct) =>
+                (journey, node3, ct) =>
                 {
                     return Task.FromResult(builder.Map.NodeSpy4);
                 },
@@ -206,7 +206,7 @@ public sealed class ChainedGotoDo : IDisposable
         var sut = await journey
             .GotoAsync<Node2>()
             .GotoDoAsync<Node3, EnrichedNode<Node4>>(
-                (journey, node2, ct) =>
+                (journey, node3, ct) =>
                 {
                     var actionMetadata = new ActionMetaData("My custom metadata");
                     var enrichedNode = new EnrichedNode<Node4>(
@@ -247,11 +247,11 @@ public sealed class ChainedGotoDo : IDisposable
         var sut = await journey
             .GotoAsync<Node1>()
             .GotoDoAsync<Node3, Node4>(
+                waypoints,
                 (journey, node3, ct) =>
                 {
                     return Task.FromResult(builder.Map.NodeSpy4);
                 },
-                waypoints,
                 CancellationToken.None
             );
 
@@ -289,11 +289,11 @@ public sealed class ChainedGotoDo : IDisposable
         var sut = await journey
             .GotoAsync<Node1>()
             .GotoDoAsync<Node4, Node5>(
-                (journey, node1, ct) =>
+                excludedWaypoints,
+                (journey, node4, ct) =>
                 {
                     return Task.FromResult(builder.Map.NodeSpy5);
                 },
-                excludedWaypoints,
                 CancellationToken.None
             );
 
@@ -335,12 +335,12 @@ public sealed class ChainedGotoDo : IDisposable
         var sut = await journey
             .GotoAsync<Node1>()
             .GotoDoAsync<Node5, Node6>(
-                (journey, node1, ct) =>
+                waypoints,
+                excludedWaypoints,
+                (journey, node5, ct) =>
                 {
                     return Task.FromResult(builder.Map.NodeSpy6);
                 },
-                waypoints,
-                excludedWaypoints,
                 CancellationToken.None
             );
 

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test1.When_current_origin_and_target_is_the_same_node.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test1.When_current_origin_and_target_is_the_same_node.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0
+Node1->>Node1:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test2.When_current_origin_and_target_is_the_same_node_is_the_same_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test2.When_current_origin_and_target_is_the_same_node_is_the_same_with_enriched_metadata.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0
+Node1->>Node1:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test3.When_current_and_origin_is_same_node_but_target_is_different.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test3.When_current_and_origin_is_same_node_but_target_is_different.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0
+Node1->>Node2:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test4.When_current_and_origin_is_same_node_but_target_is_different_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test4.When_current_and_origin_is_same_node_but_target_is_different_with_enriched_metadata.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node1:0
+Node1->>Node2:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test5.When_current_origin_and_target_are_all_different.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test5.When_current_origin_and_target_are_all_different.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0
+Node3->>Node4:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test6.When_current_origin_and_target_are_all_different_with_enriched_metadata.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test6.When_current_origin_and_target_are_all_different_with_enriched_metadata.verified.mmd
@@ -1,0 +1,4 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0
+Node3->>Node4:0<br>My custom metadata

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test7.With_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test7.With_waypoints.verified.mmd
@@ -1,0 +1,5 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node2:0
+Node2->>Node3:0
+Node3->>Node4:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test8.With_excluded_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test8.With_excluded_waypoints.verified.mmd
@@ -1,0 +1,5 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node2:0
+Node2->>Node4:99
+Node4->>Node5:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test9.With_included_and_excluded_waypoints.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/GotoDo/Chained/ChainedGotoDo_Snapshots/Test9.With_included_and_excluded_waypoints.verified.mmd
@@ -1,0 +1,6 @@
+﻿sequenceDiagram
+Node1->>Node1:0
+Node1->>Node2:0
+Node2->>Node4:99
+Node4->>Node5:0
+Node5->>Node6:0<br>Journey.DoAsync

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedAllowsToAddMetadata.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedAllowsToAddMetadata.cs
@@ -37,7 +37,7 @@ public sealed class ChainedAllowsToAddMetadata : IDisposable
         var sut = await journey
             .GotoAsync<Node2>()
             .DoAsync<Node2, EnrichedNode<Node2>>(
-                (journey, node2, ct) =>
+                (node2, ct) =>
                 {
                     var actionMetadata = new ActionMetaData("My custom metadata");
                     var enrichedNode = new EnrichedNode<Node2>(node2, actionMetadata);

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode.cs
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode.cs
@@ -1,12 +1,50 @@
-﻿namespace Caravel.Core.UnitTests.Tests.NodeAction.Chained;
+﻿using Caravel.Abstractions;
+
+namespace Caravel.Core.UnitTests.Tests.NodeAction.Chained;
 
 [Trait(TestType, Unit)]
 [Trait(Feature, FeatureNodeAction)]
 [Trait(Domain, NodeDomain)]
 public class ChainedChangesTheCurrentNode
 {
-    [Fact(DisplayName = "When action returns a different node")]
+    [Fact(DisplayName = $"When action returns a different node using {nameof(IJourney)}")]
     public async Task Test1()
+    {
+        // Arrange
+        var builder = new JourneyBuilder()
+            .AddNode<Node1>()
+            .WithEdge<Node2>()
+            .Done()
+            .AddNode<Node2>()
+            .WithEdge<Node3>()
+            .Done()
+            .AddNode<Node3>()
+            .WithEdge<Node4>()
+            .Done()
+            .AddNode<Node4>()
+            .WithEdge<Node5>()
+            .Done()
+            .AddNode<Node5>()
+            .Done();
+
+        var journey = builder.Build();
+        // Act
+        // csharpier-ignore
+        var sut = await journey
+            .GotoAsync<Node3>()
+            .DoAsync<Node3, Node4>(
+                (journey, node, ct)
+                => Task.FromResult(journey.OfType<SmartJourney>().Map.NodeSpy4)
+            )
+            .GotoAsync<Node5>();
+
+        // Assert
+        var result = await sut.ToMermaidSequenceDiagramMarkdownAsync(WithDescription);
+        await result.VerifyMermaidMarkdownAsync();
+    }
+
+    [Fact(DisplayName = "When action returns a different node using closure")]
+    public async Task Test2()
     {
         // Arrange
         var builder = new JourneyBuilder()
@@ -30,11 +68,10 @@ public class ChainedChangesTheCurrentNode
         // Act
         // csharpier-ignore
         var sut = await journey
-            .GotoAsync<Node2>()
-            .DoAsync<Node2, Node3>((node, ct) => Task.FromResult(map.NodeSpy3))
+            .GotoAsync<Node3>()
             .DoAsync<Node3, Node4>(
-                (journey, node, ct)
-                => Task.FromResult(journey.OfType<SmartJourney>().Map.NodeSpy4)
+                (node, ct)
+                => Task.FromResult(map.NodeSpy4)
             )
             .GotoAsync<Node5>();
 

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node_using_IJourney.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode_Snapshots/Test1.When_action_returns_a_different_node_using_IJourney.verified.mmd
@@ -1,5 +1,5 @@
 ﻿sequenceDiagram
 Node1->>Node2:0
-Node2->>Node3:0<br>Journey.DoAsync
+Node2->>Node3:0
 Node3->>Node4:0<br>Journey.DoAsync
 Node4->>Node5:0

--- a/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode_Snapshots/Test2.When_action_returns_a_different_node_using_closure.verified.mmd
+++ b/test/UnitTests/Caravel.Core.UnitTests/Tests/NodeAction/Chained/ChainedChangesTheCurrentNode_Snapshots/Test2.When_action_returns_a_different_node_using_closure.verified.mmd
@@ -1,0 +1,5 @@
+﻿sequenceDiagram
+Node1->>Node2:0
+Node2->>Node3:0
+Node3->>Node4:0<br>Journey.DoAsync
+Node4->>Node5:0


### PR DESCRIPTION
`GotoDoAsync<TOriginNode, TTargetNode>` can be used to combine navigation and action in a single step. It navigates to `TOriginNode` and performs the specified action returning `TTargnetNode`. `TTargnetNode` can be the same as `TOriginNode` to perform actions without changing nodes.