### PR TITLE
On node visited

### DIFF
--- a/docs/sequence-diagrams/journey.goto.mmd
+++ b/docs/sequence-diagrams/journey.goto.mmd
@@ -1,0 +1,44 @@
+sequenceDiagram
+    participant Journey            as Journey
+    participant Ext                as JourneyExtensions
+    participant EmptyExcl          as EmptyExcludedWaypoints
+    participant Graph              as Graph
+    participant CurrentNode        as CurrentNode
+    participant Edge               as Edge
+    participant NeighborNavigator  as NeighborNavigator
+    participant JourneyLegFactory  as JourneyLegFactory
+    participant JourneyLegPublisher as JourneyLegPublisher
+
+    %% ---- 1. Extension entry ------------------------------------
+    Journey->>Ext: GotoAsync<Node3>()  
+    Ext->>Journey: GotoAsync<Node3>(EmptyWaypoints.Create() and EmptyExcludedWaypoints.Create() and token)
+
+    %% ---- 3. Visit starting node --------------------------------
+    Journey->>CurrentNode: OnNodeVisitedAsync(journey, token)
+
+    %% ---- 4. Resolve route ---------------------------------------
+    Journey->>Graph: GetRoute(originType, destinationType, waypoints, excludedWaypoints)
+    Graph-->>Journey: route
+
+    %% ---- 5. Create journey leg ----------------------------------
+    Journey->>JourneyLegFactory: CreateJourneyLeg(Id, legEdges, route)
+    JourneyLegFactory-->>Journey: journeyLeg
+
+    %% ---- 6. Publish leg started --------------------------------
+    Journey->>JourneyLegPublisher: PublishOnJourneyLegStartedAsync(event and token)
+
+    %% ---- 7. Navigate through the edges --------------------------
+    loop each edge in route.Edges
+        Journey->>Edge: edge
+        Edge->>NeighborNavigator: MoveNext(journey, token)
+        NeighborNavigator-->>Journey: newNode
+        Journey->>CurrentNode: OnNodeVisitedAsync(journey, token)
+        Journey->>journeyLeg: Edges.Enqueue(edge)
+        Journey->>JourneyLegPublisher: PublishOnJourneyLegUpdatedAsync(event and token)
+    end
+
+    %% ---- 8. Finish the leg --------------------------------------
+    Journey->>JourneyLegPublisher: PublishOnJourneyLegCompletedAsync(event and token)
+
+    %% ---- 9. Final node visit ------------------------------------
+    Journey->>CurrentNode: OnNodeVisitedAsync(journey, token)

--- a/src/Caravel.Core/Journey.cs
+++ b/src/Caravel.Core/Journey.cs
@@ -139,6 +139,11 @@ public class Journey : IJourney
             )
             .ConfigureAwait(false);
 
+        // Visit the new current node
+        await CurrentNode
+            .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
+            .ConfigureAwait(false);
+
         return this;
     }
 
@@ -183,8 +188,6 @@ public class Journey : IJourney
                     linkedCancellationTokenSource.Token
                 )
                 .ConfigureAwait(false);
-
-            linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
             await targetNode
                 .OnNodeVisitedAsync(this, linkedCancellationTokenSource.Token)
@@ -354,7 +357,5 @@ public class Journey : IJourney
         {
             throw new UnexpectedNodeException(destinationType, CurrentNode.GetType());
         }
-
-        await CurrentNode.OnNodeVisitedAsync(this, cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
Move OnNodeVisitedAsync from Journey.CompleteJourneyLegAsync to GotoAsync and DoAsync.
Makes it easier to find since not related to JourneyLeg. Also it removes one unnecessary visit from DoAsync.